### PR TITLE
add a `get_butler` convenient function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Providing consistent access to DC2 DM data products in DESC Python environments.
 
 ## Usage
 ```python
-from desc_dc2_dm_data import REPOS
-import lsst.daf.persistence as dafPersist
+from desc_dc2_dm_data import get_butler, REPOS
 
-butler = dafPersist.Butler(REPOS['1.2i'])
+butler = get_butler('1.2i')
+
+print('Repo path to 1.2p', REPOS['1.2p'])
 ```

--- a/desc_dc2_dm_data/__init__.py
+++ b/desc_dc2_dm_data/__init__.py
@@ -4,6 +4,4 @@ __init__.py
 
 from .version import *
 from .repos import *
-
-from . import fix_stack
-del fix_stack
+from .butler import *

--- a/desc_dc2_dm_data/butler.py
+++ b/desc_dc2_dm_data/butler.py
@@ -1,0 +1,29 @@
+"""
+butler.py
+convenient function to get the butler of a specific run
+"""
+
+from lsst.daf.persistence import Butler
+from .repos import REPOS
+from . import fix_stack
+del fix_stack
+
+__all__ = ['get_butler']
+
+def get_butler(run):
+    """
+    A convenient function to get the butler of a specific run.
+
+    Parameters
+    ----------
+    run : str
+        run name (e.g. "1.1p")
+
+    Returns
+    -------
+    butler : lsst.daf.persistence.Butler instance
+
+    """
+    if run not in REPOS:
+        raise KeyError('Run {} is not available'.format(run))
+    return Butler(REPOS[run])

--- a/desc_dc2_dm_data/version.py
+++ b/desc_dc2_dm_data/version.py
@@ -1,4 +1,4 @@
 """
 version.py
 """
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
This PR adds a `get_butler` convenient function, which can work as follows:

```python
from desc_dc2_dm_data import get_butler
butler = get_butler('1.2i')
```

This PR also increases the version to 0.1.1.