### PR TITLE
Revert "update 1.2i repo path"

### DIFF
--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -8,5 +8,5 @@ __all__ = ['REPOS']
 REPOS = {
     '1.1p': '/global/cscratch1/sd/desc/DC2/data/Run1.1p/Run1.1/output',
     '1.2p': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
-    '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/coadd-v1',
+    '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
 }

--- a/desc_dc2_dm_data/version.py
+++ b/desc_dc2_dm_data/version.py
@@ -1,4 +1,4 @@
 """
 version.py
 """
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/desc_dc2_dm_data/version.py
+++ b/desc_dc2_dm_data/version.py
@@ -1,4 +1,4 @@
 """
 version.py
 """
-__version__ = '0.1.1'
+__version__ = '0.1.0'


### PR DESCRIPTION
Reverts LSSTDESC/desc-dc2-dm-data#2  I realize now that we can avoid the need to change this repo at all, as long as we standardize the naming of the output directories using symlinks.  I've done that for the current Run1.2i reprocessing, providing a `rerun/multiband` link and that allows the notebooks to work correctly.