### PR TITLE
Update Run2.1i paths to follow DR definitions

### DIFF
--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -11,7 +11,7 @@ REPOS = {
     '1.2p_v4': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
     '1.2p_v3': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
     '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
-    '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+    '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
     '2.1i_v1': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
     '2.1i_dr1a': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
     '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -11,6 +11,7 @@ REPOS = {
     '1.2p_v4': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
     '1.2p_v3': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
     '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
-    '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
-    '2.1i_v1': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+    '2.1i_dr1a': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+    '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',
+    '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
 }

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -11,6 +11,8 @@ REPOS = {
     '1.2p_v4': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
     '1.2p_v3': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
     '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
+    '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+    '2.1i_v1': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
     '2.1i_dr1a': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
     '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',
     '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',


### PR DESCRIPTION
Finally fixed Run2.1i DR paths to point to the proper locations on NERSC CSCRATCH