### PR TITLE
Add new Run2.2i DR3

### DIFF
--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -18,5 +18,6 @@ REPOS = {
     '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
     '2.2i_dr2_tract3828': '/global/cscratch1/sd/desc/DC2/data/Run2.2i/rerun/run2.2-coadd-wfd-y1-v1',
     '2.2i_dr3': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
+    '2.2i_dia_y2_t3828': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-t3828-dia-y2-v1',
     'dia_2020Jan': '/global/cscratch1/sd/bos0109/templates_rect',
 }

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -17,5 +17,6 @@ REPOS = {
     '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',
     '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
     '2.2i_dr2_tract3828': '/global/cscratch1/sd/desc/DC2/data/Run2.2i/rerun/run2.2-coadd-wfd-y1-v1',
+    '2.2i_dr3': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
     'dia_2020Jan': '/global/cscratch1/sd/bos0109/templates_rect',
 }

--- a/desc_dc2_dm_data/version.py
+++ b/desc_dc2_dm_data/version.py
@@ -1,4 +1,4 @@
 """
 version.py
 """
-__version__ = '0.3.0'
+__version__ = '0.5.0'


### PR DESCRIPTION
Testing that CFS at NERSC can be used in batch, so there is no longer a need to copy the data to CSCRATCH.  Added a new entry for Run2.2i DR3 - and will test this with the desc-stack env.