### PR TITLE
Update README.md to give examples that work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Providing consistent access to DC2 DM data products in DESC Python environments.
 ```python
 from desc_dc2_dm_data import get_butler, REPOS
 
-butler = get_butler('1.2i')
+butler = get_butler('1.2p')
 
-print('Repo path to 1.2p', REPOS['1.2p'])
+print('Repo path to 2.1i', REPOS['2.1i'])
 ```


### PR DESCRIPTION
Run 1.2i is no longer available on NERSC so the previous `get_butler` example doesn't work.