### PR TITLE
add site.py to extract site info

### DIFF
--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -2,23 +2,44 @@
 repos.py
 paths to current repos
 """
+
+import warnings
+from .site import SITE_INFO
+
 __all__ = ['REPOS']
 
-# current available runs
-REPOS = {
-    '1.1p': '/global/cscratch1/sd/desc/DC2/data/Run1.1p/Run1.1/output',
-    '1.2p': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
-    '1.2p_v4': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
-    '1.2p_v3': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
-    '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
-    '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
-    '2.1i_v1': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
-    '2.1i_dr1a': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
-    '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',
-    '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
-    '2.2i_dr2_tract3828': '/global/cscratch1/sd/desc/DC2/data/Run2.2i/rerun/run2.2-coadd-wfd-y1-v1',
-    '2.2i_dr3': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
-    '2.2i_dia_y2_t3828': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-t3828-dia-y2-v1',
-    '2.2i_dr6_wfd': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr6-v1',
-    'dia_2020Jan': '/global/cscratch1/sd/bos0109/templates_rect',
+# current available runs at NERSC and IN2P3
+_REPOS = {
+    "nersc": {
+        '1.1p': '/global/cscratch1/sd/desc/DC2/data/Run1.1p/Run1.1/output',
+        '1.2p': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
+        '1.2p_v4': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_39/rerun/coadd-v4',
+        '1.2p_v3': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/w_2018_30/rerun/coadd-all2',
+        '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',
+        '2.1i': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
+        '2.1i_v1': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+        '2.1i_dr1a': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-v1',
+        '2.1i_dr1b': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr1b-v1',
+        '2.1i_dr4': '/global/cscratch1/sd/desc/DC2/data/Run2.1i/rerun/coadd-dr4-v1',
+        '2.2i_dr2_tract3828': '/global/cscratch1/sd/desc/DC2/data/Run2.2i/rerun/run2.2-coadd-wfd-y1-v1',
+        '2.2i_dr3': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
+        '2.2i_dia_y2_t3828': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-t3828-dia-y2-v1',
+        '2.2i_dr6_wfd': '/global/cfs/cdirs/lsst/production/DC2_ImSim/Run2.2i/desc_dm_drp/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr6-v1',
+        'dia_2020Jan': '/global/cscratch1/sd/bos0109/templates_rect',
+    },
+
+    "in2p3": {
+        # TODO: add repo paths
+    },
 }
+
+
+def choose_repos_by_site():
+    for site, repos in _REPOS:
+        if site in SITE_INFO:
+            return repos
+    warnings.warn("Site '{}' not recognized. Default to nersc.".format(SITE_INFO))
+    return _REPOS["nersc"]
+
+
+REPOS = choose_repos_by_site()

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -29,12 +29,14 @@ _REPOS = {
     },
 
     "in2p3": {
-        # TODO: add repo paths
+        '2.2i_dr3': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr2-v1',
+        '2.2i_dr6_wfd': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr6-v1',
     },
 }
 
 
 def choose_repos_by_site():
+    print(_REPOS)
     for site, repos in _REPOS:
         if site in SITE_INFO:
             return repos

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -35,7 +35,7 @@ _REPOS = {
 
 
 def choose_repos_by_site():
-    for site, repos in _REPOS:
+    for site, repos in _REPOS.items():
         if site in SITE_INFO:
             return repos
     warnings.warn("Site '{}' not recognized. Default to nersc.".format(SITE_INFO))

--- a/desc_dc2_dm_data/repos.py
+++ b/desc_dc2_dm_data/repos.py
@@ -29,7 +29,16 @@ _REPOS = {
     },
 
     "in2p3": {
-        '2.2i_dr3': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr2-v1',
+        '1.2p': '/sps/lsst/dataproducts/desc/DC2/Run1.2p/w_2018_39/rerun/coadd-v4',
+        '1.2p_v4': '/sps/lsst/dataproducts/desc/DC2/Run1.2p/w_2018_39/rerun/coadd-v4',
+        '1.2p_v3': '/sps/lsst/dataproducts/desc/DC2/Run1.2p/w_2018_30/rerun/coadd-all2',
+        '1.2i': '/sps/lsst/dataproducts/desc/DC2/Run1.2i/w_2018_39/rerun/coadd-v1/',
+        '2.1i_v1': '/sps/lsst/dataproducts/desc/DC2/Run2.1i/w_2019_19-v1/rerun/coadd-v1',
+        '2.1i_dr1a': '/sps/lsst/dataproducts/desc/DC2/Run2.1i/w_2019_19-v1/rerun/coadd-v1',
+        '2.1i_dr1b': '/sps/lsst/dataproducts/desc/DC2/Run2.1i/w_2019_19-v1/rerun/coadd-dr1b-v1',
+        '2.2i_dr2_tract3828': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-t3828-dia-y2-v1',
+        '2.2i_dr2': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
+        '2.2i_dr3': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr3-v1',
         '2.2i_dr6_wfd': '/sps/lssttest/dataproducts/desc/DC2/Run2.2i/v19.0.0-v1/rerun/run2.2i-coadd-wfd-dr6-v1',
     },
 }

--- a/desc_dc2_dm_data/site.py
+++ b/desc_dc2_dm_data/site.py
@@ -1,0 +1,34 @@
+"""
+site.py
+Extract site info.
+"""
+
+import os
+import socket
+import warnings
+
+__all__ = ["SITE_INFO"]
+
+# We utilize the same environment variable used in https://github.com/LSSTDESC/gcr-catalogs
+_DESC_SITE_ENV = "DESC_GCR_SITE"
+
+
+def get_site_info():
+    """
+    Return a string which, when executing at a recognized site with
+    well-known name, will include the name for that site
+    """
+    site_from_env = os.getenv(_DESC_SITE_ENV, default="")
+    site_from_socket = socket.getfqdn()
+    if site_from_env:
+        if site_from_socket and site_from_env not in site_from_socket and not (
+            site_from_env == "nersc" and site_from_socket.startswith("nid")
+        ):
+            warnings.warn("Site determined from env variable {} = {}, which differs from node name {}".format(
+                _DESC_SITE_ENV, site_from_env, site_from_socket
+            ))
+        return site_from_env
+    return site_from_socket
+
+
+SITE_INFO = get_site_info()

--- a/desc_dc2_dm_data/version.py
+++ b/desc_dc2_dm_data/version.py
@@ -1,4 +1,4 @@
 """
 version.py
 """
-__version__ = '0.6.0'
+__version__ = '0.7.0-alpha'


### PR DESCRIPTION
This PR is to resolve #17. I implemented the same site extraction method in https://github.com/LSSTDESC/gcr-catalogs/, and the module will choose the corresponding `REPOS` dictionary at load time. 

The repo paths at IN2P3 have can be added in a separated PR. 